### PR TITLE
Campaign summaries shows correct information after redirect

### DIFF
--- a/src/hooks/useCreateCampaign.js
+++ b/src/hooks/useCreateCampaign.js
@@ -1,24 +1,26 @@
 import { addDoc, collection } from "firebase/firestore";
 import { db } from "../config/firebase-config";
-import { useGetUserInfo } from './useGetUserInfo';
 
 export const useCreateCampaign = () => {
-    const transactionCollectionRef = collection(db, "campaigns");
+    const campaignCollectionRef = collection(db, "campaigns");
     const createCampaign = async ({
         userID, 
         description, 
         campaignName
     }) => {
-        console.log(userID);
-        console.log(description);
-        console.log(campaignName);
-        await addDoc(transactionCollectionRef, {
+
+        const campaignRef = await addDoc(campaignCollectionRef, {
             creator: userID,
             description: description,
             name: campaignName,
             players: [userID]
         });
+
+        console.log("id of new campaign: ",campaignRef.id);
+
+        localStorage.setItem("currentCampaign", campaignRef.id);
     };
-     return {createCampaign};
+
+    return {createCampaign};
 
 }

--- a/src/hooks/useCreateCampaign.js
+++ b/src/hooks/useCreateCampaign.js
@@ -16,7 +16,7 @@ export const useCreateCampaign = () => {
             players: [userID]
         });
 
-        console.log("id of new campaign: ",campaignRef.id);
+        //console.log("id of new campaign: ",campaignRef.id);
 
         localStorage.setItem("currentCampaign", campaignRef.id);
     };

--- a/src/hooks/useGetCampaignByID.js
+++ b/src/hooks/useGetCampaignByID.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../config/firebase-config';
+import { useGetUserInfo } from "./useGetUserInfo";
+
+export const useGetCampaignByID = async () => {
+    const [campaign, setCampaign] = useState([]);
+    const campaignID = localStorage.getItem("currentCampaign");
+
+    const campaignRef = doc(db, "campaigns", campaignID);
+    const campaignSnap = await getDoc(campaignRef);
+
+    if (campaignSnap.exists()) {
+        //console.log("Document data:", campaignSnap.data());
+        setCampaign(campaignSnap);
+    } else {
+        console.log("No such campaign!");
+    }
+
+    return { campaign };
+};

--- a/src/hooks/useGetCampaignByID.js
+++ b/src/hooks/useGetCampaignByID.js
@@ -2,20 +2,29 @@ import { useEffect, useState } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../config/firebase-config';
 import { useGetUserInfo } from "./useGetUserInfo";
+import { SignInMethod } from 'firebase/auth';
 
 export const useGetCampaignByID = async () => {
-    const [campaign, setCampaign] = useState([]);
+    let [campaign, setCampaign] = useState({
+        players: [],
+        creator: "",
+        decription: "",
+        name: ""
+    });
     const campaignID = localStorage.getItem("currentCampaign");
 
     const campaignRef = doc(db, "campaigns", campaignID);
     const campaignSnap = await getDoc(campaignRef);
 
-    if (campaignSnap.exists()) {
-        //console.log("Document data:", campaignSnap.data());
-        setCampaign(campaignSnap);
-    } else {
-        console.log("No such campaign!");
-    }
+    campaign = campaignSnap.data();
 
+    //if (campaignSnap.exists()) {
+        //console.log("Document data:", campaignSnap.data());
+        //console.log(JSON.stringify(campaignSnap.data()));
+        //setCampaign(campaignSnap.data());
+    //} else {
+        //console.log("No such campaign!");
+    //}
+    console.log(JSON.stringify(campaign));
     return { campaign };
-};
+}

--- a/src/hooks/useGetCampaignByID.js
+++ b/src/hooks/useGetCampaignByID.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { db } from '../config/firebase-config';
 import { doc, getDoc } from "firebase/firestore";
 
-export const useGetCampaignByID = ({props}) => {
+export const useGetCampaignByID = (props) => {
     // let [campaign, setCampaign] = useState({
     //     players: [],
     //     creator: "",
@@ -15,7 +15,8 @@ export const useGetCampaignByID = ({props}) => {
     // const campaignSnap = getDoc(campaignRef);
     // campaign = campaignSnapawait.data();
 
-    const campaignID = props
+    const campaignID = props;
+    console.log(props)
 
     const [campaignName, setCampaignNames] = useState("");
     const [campaignDesc, setCampaignDesc] = useState("");
@@ -23,7 +24,7 @@ export const useGetCampaignByID = ({props}) => {
 
     const getCampaign = async () => {
         
-        const ref = doc(db, "campaigns", "doVE7nXY8lukkPykw6hM");
+        const ref = doc(db, "campaigns", campaignID);
         const campaignDoc = await getDoc(ref);
 
         if (!campaignDoc.exists()) {

--- a/src/hooks/useGetCampaignByID.js
+++ b/src/hooks/useGetCampaignByID.js
@@ -1,30 +1,55 @@
 import { useEffect, useState } from 'react';
-import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../config/firebase-config';
-import { useGetUserInfo } from "./useGetUserInfo";
-import { SignInMethod } from 'firebase/auth';
+import { doc, getDoc } from "firebase/firestore";
 
-export const useGetCampaignByID = async () => {
-    let [campaign, setCampaign] = useState({
-        players: [],
-        creator: "",
-        decription: "",
-        name: ""
-    });
-    const campaignID = localStorage.getItem("currentCampaign");
+export const useGetCampaignByID = ({props}) => {
+    // let [campaign, setCampaign] = useState({
+    //     players: [],
+    //     creator: "",
+    //     decription: "",
+    //     name: ""
+    // });
+    // const campaignID = localStorage.getItem("currentCampaign");
 
-    const campaignRef = doc(db, "campaigns", campaignID);
-    const campaignSnap = await getDoc(campaignRef);
+    // const campaignRef = doc(db, "campaigns", campaignID);
+    // const campaignSnap = getDoc(campaignRef);
+    // campaign = campaignSnapawait.data();
 
-    campaign = campaignSnap.data();
+    const campaignID = props
 
-    //if (campaignSnap.exists()) {
-        //console.log("Document data:", campaignSnap.data());
-        //console.log(JSON.stringify(campaignSnap.data()));
-        //setCampaign(campaignSnap.data());
-    //} else {
-        //console.log("No such campaign!");
-    //}
-    console.log(JSON.stringify(campaign));
-    return { campaign };
+    const [campaignName, setCampaignNames] = useState("");
+    const [campaignDesc, setCampaignDesc] = useState("");
+
+
+    const getCampaign = async () => {
+        
+        const ref = doc(db, "campaigns", "doVE7nXY8lukkPykw6hM");
+        const campaignDoc = await getDoc(ref);
+
+        if (!campaignDoc.exists()) {
+            console.log("Doc doesn't exist");
+        } else {
+            console.log("Doc exists");
+            const campaignData = campaignDoc.data();
+            // console.log(JSON.stringify(campaignData), "retrieved data");
+            setCampaignNames(campaignData["name"]);
+            setCampaignDesc(campaignData["description"]);
+            console.log(campaignName, campaignDesc);
+        }
+        
+    }
+
+    useEffect(() => {
+        getCampaign()
+    }, [])
+
+
+    // if (campaignSnap.exists()) {
+    //     console.log("Document data:", campaignSnap.data());
+    //     console.log(JSON.stringify(campaignSnap.data()));
+    //     setCampaign(campaignSnap.data());
+    // } else {
+    //     console.log("No such campaign!");
+    // }
+    return { campaignName, campaignDesc };
 }

--- a/src/pages/campaign-selection/index.js
+++ b/src/pages/campaign-selection/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate} from 'react-router-dom';
 import { useCreateCampaign } from "../../hooks/useCreateCampaign";
 import { useGetUserInfo } from '../../hooks/useGetUserInfo';
 

--- a/src/pages/campaign-selection/index.js
+++ b/src/pages/campaign-selection/index.js
@@ -10,9 +10,9 @@ export const CampaignSelection = () => {
     const [campaignName, setCampaignName] = useState("");
     const [description, setDescription] = useState("");
 
-    const createCampaignSubmit = (e) => {    //form for creating a new campaign
+    const createCampaignSubmit = async (e) => {    //form for creating a new campaign
         e.preventDefault();
-        createCampaign({
+        await createCampaign({
             userID,
             campaignName,
             description

--- a/src/pages/campaign-summaries/index.js
+++ b/src/pages/campaign-summaries/index.js
@@ -3,10 +3,10 @@ import { useGetCampaignByID } from "../../hooks/useGetCampaignByID"
 
 export const CampaignSummaries = () => {
     const campaignID = localStorage.getItem("currentCampaign");
-    console.log(campaignID);
+    //console.log(campaignID);
     const {campaignName, campaignDesc} = useGetCampaignByID(campaignID);
 
-    console.log("outside hook");
+    //console.log("outside hook");
 
     return <>
         <h1>Campaign Summaries</h1>

--- a/src/pages/campaign-summaries/index.js
+++ b/src/pages/campaign-summaries/index.js
@@ -2,10 +2,15 @@ import { useGetCampaignByID } from "../../hooks/useGetCampaignByID"
 
 
 export const CampaignSummaries = () => {
-    const currentCampaign = useGetCampaignByID();
+    const campaign = useGetCampaignByID();
     const campaignID = localStorage.getItem("currentCampaign");
 
+    console.log(JSON.stringify(campaign));
+
     return <>
-        <p>CampaignSummaries {campaignID}</p>
+        <h1>Campaign Summaries</h1>
+        <p>Campaign ID: {campaignID}</p>
+        <p>Campaign name: {campaign["name"]}</p>
+        <p>Campaign description: {campaign["description"]}</p>
     </>
 }

--- a/src/pages/campaign-summaries/index.js
+++ b/src/pages/campaign-summaries/index.js
@@ -2,15 +2,16 @@ import { useGetCampaignByID } from "../../hooks/useGetCampaignByID"
 
 
 export const CampaignSummaries = () => {
-    const campaign = useGetCampaignByID();
     const campaignID = localStorage.getItem("currentCampaign");
+    console.log(campaignID);
+    const {campaignName, campaignDesc} = useGetCampaignByID(campaignID);
 
-    console.log(JSON.stringify(campaign));
+    console.log("outside hook");
 
     return <>
         <h1>Campaign Summaries</h1>
         <p>Campaign ID: {campaignID}</p>
-        <p>Campaign name: {campaign["name"]}</p>
-        <p>Campaign description: {campaign["description"]}</p>
+        <p>Campaign name: {campaignName}</p>
+        <p>Campaign description: {campaignDesc}</p>
     </>
 }

--- a/src/pages/campaign-summaries/index.js
+++ b/src/pages/campaign-summaries/index.js
@@ -1,3 +1,11 @@
+import { useGetCampaignByID } from "../../hooks/useGetCampaignByID"
+
+
 export const CampaignSummaries = () => {
-    return <p>CampaignSummaries</p>
+    const currentCampaign = useGetCampaignByID();
+    const campaignID = localStorage.getItem("currentCampaign");
+
+    return <>
+        <p>CampaignSummaries {campaignID}</p>
+    </>
 }


### PR DESCRIPTION
After creating a new campaign on the campaign selection page, users will now be automatically redirected to a campaign-summaries page that shows that new campaign's information.
- updated useCreateCampaign to store the new campaign's id
- created useGetCampaignByID to retrieve campaign information from the firestore database
- updated the index.js page for campaign-summaries to display relevant information about the campaign whose id is stored in local storage.